### PR TITLE
Remove duplicate definition of oscar_to_HC_Q

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EulerStratifications"
 uuid = "07721d6d-e339-442c-97d1-636a42e10df6"
 authors = ["Simon Telen <telen@mis.mpg.de>", "Maximilian Wiesmann <wiesmann@mis.mpg.de>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/CoincidentRootLoci.jl
+++ b/src/CoincidentRootLoci.jl
@@ -126,15 +126,6 @@ function numerical_univariate_stratum(d, A, stratum; K=QQ, verbose=false)
     return gens
 end
 
-
-# convert Oscar polynomial f into HomotopyContinuation expression in vars
-function oscar_to_HC_Q(f, vars)
-    cffs = convert.(Rational{Int64},collect(Oscar.coefficients(f)))
-    exps = collect(Oscar.exponents(f))
-    sum([cffs[i]*prod(vars.^exps[i]) for i = 1:length(cffs)])
-end
-
-
 @doc raw"""
     get_strata_numerically(stratum::Tuple{Vector{Int}, Tuple{Int, Int}}; K=QQ, max_deg=-1, verbose=false)
 


### PR DESCRIPTION
`oscar_to_HC_Q` was defined in `CoincidentRootLoci.jl` and `utils.jl`, raising an error preventing precompilation. This PR removes the duplicate definition, so precompilation works again. 